### PR TITLE
update chart versions for infraconfig and ocs-operator to 0.2.1

### DIFF
--- a/infraconfig/Chart.yaml
+++ b/infraconfig/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 appVersion: "1.0"
 dependencies:
   - name: refarch-infraconfig
-    version: 0.2.0
+    version: 0.2.1
     repository: https://cloud-native-toolkit.github.io/toolkit-charts/

--- a/storage/Chart.yaml
+++ b/storage/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 appVersion: "1.0"
 dependencies:
   - name: ocs-operator
-    version: 0.2.0
+    version: 0.2.1
     repository: https://cloud-native-toolkit.github.io/toolkit-charts/


### PR DESCRIPTION
This Pull request is related to https://github.com/cloud-native-toolkit/toolkit-charts/pull/237 - should only be merged once the toolkit-charts Pull request has been incorporated.