### PR TITLE
Add default SA for Watson Openscale

### DIFF
--- a/serviceaccounts/tools/default-sa.yaml
+++ b/serviceaccounts/tools/default-sa.yaml
@@ -1,0 +1,7 @@
+# Watson Openscale's Kafka, Etcd, and Redis deployments use the default SA to pull.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+imagePullSecrets:
+  - name: ibm-entitlement-key


### PR DESCRIPTION
Currently the kafka, etcd and redi stateful sets in Watson Openscale are using the default service account to pull images - this is bug/deployment script typo that is being fixed by WOS dev team in the 4.0.8 release. In the meantime adding default sa.