### PR TITLE
Sterling File Gateway refactor - together with services and PR

### DIFF
--- a/namespaces/b2bi-nonprod/namespace.yaml
+++ b/namespaces/b2bi-nonprod/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: b2bi-nonprod

--- a/namespaces/b2bi-prod/namespace.yaml
+++ b/namespaces/b2bi-prod/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: b2bi-prod

--- a/serviceaccounts/b2bi-nonprod/b2bi-sa.yaml
+++ b/serviceaccounts/b2bi-nonprod/b2bi-sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: b2bi
+imagePullSecrets:
+  - name: ibm-entitlement-key

--- a/serviceaccounts/b2bi-nonprod/db2-sa.yaml
+++ b/serviceaccounts/b2bi-nonprod/db2-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: db2

--- a/serviceaccounts/b2bi-nonprod/default-sa.yaml
+++ b/serviceaccounts/b2bi-nonprod/default-sa.yaml
@@ -1,0 +1,7 @@
+# Watson Openscale's Kafka, Etcd, and Redis deployments use the default SA to pull.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+imagePullSecrets:
+  - name: ibm-entitlement-key

--- a/serviceaccounts/b2bi-nonprod/mq-sa.yaml
+++ b/serviceaccounts/b2bi-nonprod/mq-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mq

--- a/serviceaccounts/b2bi-prod/b2bi-sa.yaml
+++ b/serviceaccounts/b2bi-prod/b2bi-sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: b2bi
+imagePullSecrets:
+  - name: ibm-entitlement-key

--- a/serviceaccounts/b2bi-prod/db2-sa.yaml
+++ b/serviceaccounts/b2bi-prod/db2-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: db2

--- a/serviceaccounts/b2bi-prod/default-sa.yaml
+++ b/serviceaccounts/b2bi-prod/default-sa.yaml
@@ -1,0 +1,7 @@
+# Watson Openscale's Kafka, Etcd, and Redis deployments use the default SA to pull.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+imagePullSecrets:
+  - name: ibm-entitlement-key

--- a/serviceaccounts/b2bi-prod/mq-sa.yaml
+++ b/serviceaccounts/b2bi-prod/mq-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mq

--- a/sfg-b2bi-clusterwide/ibm-b2bi-cr-scc.yaml
+++ b/sfg-b2bi-clusterwide/ibm-b2bi-cr-scc.yaml
@@ -1,0 +1,18 @@
+# (C) Copyright 2019 Syncsort Incorporated. All rights reserved.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "ibm-b2bi-scc"
+  labels:
+    app: "ibm-b2bi-scc"
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - "ibm-b2bi-scc"
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/sfg-b2bi-clusterwide/ibm-b2bi-cr.yaml
+++ b/sfg-b2bi-clusterwide/ibm-b2bi-cr.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  name: "ibm-b2bi-psp"
+  labels:
+    app: "ibm-b2bi-psp"
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - "ibm-b2bi-psp"
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/sfg-b2bi-clusterwide/ibm-b2bi-psp.yaml
+++ b/sfg-b2bi-clusterwide/ibm-b2bi-psp.yaml
@@ -1,0 +1,60 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  name: "ibm-b2bi-psp"
+  labels:
+    app: "ibm-b2bi-psp"
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  allowedCapabilities:
+  requiredDropCapabilities:
+  - MKNOD
+  - AUDIT_WRITE
+  - KILL
+  - NET_BIND_SERVICE
+  - NET_RAW
+  - FOWNER
+  - FSETID
+  - SYS_CHROOT
+  - SETFCAP
+  - SETPCAP
+  - CHOWN
+  - SETGID
+  - SETUID
+  - DAC_OVERRIDE
+  allowedHostPaths:
+  runAsUser:
+    rule: MustRunAsNonRoot
+  runAsGroup:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 4294967294
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 4294967294
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+    - min: 1
+      max: 4294967294
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+  - nfs
+  forbiddenSysctls:
+  - '*'

--- a/sfg-b2bi-clusterwide/ibm-b2bi-scc.yaml
+++ b/sfg-b2bi-clusterwide/ibm-b2bi-scc.yaml
@@ -1,0 +1,59 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  name: ibm-b2bi-scc
+  labels:
+   app: "ibm-b2bi-scc"
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowPrivilegeEscalation: false
+allowedCapabilities:
+defaultAddCapabilities: []
+defaultAllowPrivilegeEscalation: false
+forbiddenSysctls:
+  - "*"
+fsGroup:
+  type: MustRunAs
+  ranges:
+  - min: 1
+    max: 4294967294
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+- AUDIT_WRITE
+- KILL
+- NET_BIND_SERVICE
+- NET_RAW
+- FOWNER
+- FSETID
+- SYS_CHROOT
+- SETFCAP
+- SETPCAP
+- CHOWN
+- SETGID
+- SETUID
+- DAC_OVERRIDE
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: MustRunAs
+  ranges:
+  - min: 1
+    max: 4294967294
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- nfs
+- persistentVolumeClaim
+- projected
+- secret
+priority: 10


### PR DESCRIPTION
Signed-off-by: Budi Darmawan <vbudi@us.ibm.com>

Current enhancement:
- merging namespace to single ns for db2, mq and sfg 
- refactor global psp/scc to a separate item in infra instead of in services (which is ns bound)

see also https://github.com/cloud-native-toolkit/multi-tenancy-gitops/pull/254